### PR TITLE
fix(#5): disable health check in CI

### DIFF
--- a/.munitor.yml
+++ b/.munitor.yml
@@ -24,8 +24,7 @@ sbom: true
 owasp: false
 
 health:
-  path: /api/health
-  port: "8000"
+  enabled: false
 
 contexts:
   registry: ghcr


### PR DESCRIPTION
## Summary

Disable the Munitor health check for Docker builds until the health endpoint is wired up in Phase 2.

The docker-build-push job fails because `/api/health` doesn't exist yet.

Closes #5

## Changes

- Set `health.enabled: false` in `.munitor.yml`