### PR TITLE
chore: bump munitor orb to 0.2

### DIFF
--- a/.munitor.yml
+++ b/.munitor.yml
@@ -1,5 +1,5 @@
 pipeline: gradle-webapp
-orb_version: dev:snapshot
+orb_version: "0.2"
 
 image_name: concilium
 java_version: "21"


### PR DESCRIPTION
Bump from dev:snapshot to stable kof22/munitor@0.2.0 (adds gradle-webapp pipeline support).